### PR TITLE
Fix/queue colision solution

### DIFF
--- a/backend/station_manager/app/src/main/java/com/StationManager/app/domain/train_station/Hall.java
+++ b/backend/station_manager/app/src/main/java/com/StationManager/app/domain/train_station/Hall.java
@@ -76,12 +76,14 @@ public class Hall {
                     nextClientInQueuePosition = MapManager.GetInitialPoint(ticketOffice);
                 }
                 else {
-                    var lastClientInQueuePosition = new Point(ticketOffice.getQueue().get(ticketOffice.getQueue().size() - 1).getPosition());
+                    var lastClientInQueuePosition = new Point(ticketOffice.getQueue().get(
+                        ticketOffice.getQueue().size() - 1).getPosition());
                     lastClientInQueuePosition.translate(step.x, step.y);
                     nextClientInQueuePosition = lastClientInQueuePosition;
                 }
 
-                return MapManager.IsSegmentFree(new Segment(nextClientInQueuePosition, nextClientInQueuePosition), this);
+                return MapManager.IsSegmentFree(
+                    new Segment(nextClientInQueuePosition, nextClientInQueuePosition), this);
             })
             .collect(Collectors.toCollection(ArrayList::new));
 

--- a/backend/station_manager/app/src/main/java/com/StationManager/app/domain/train_station/Hall.java
+++ b/backend/station_manager/app/src/main/java/com/StationManager/app/domain/train_station/Hall.java
@@ -66,9 +66,28 @@ public class Hall {
             .filter(ticketOffice -> !ticketOffice.getClosed())
             .collect(Collectors.toCollection(ArrayList::new));
 
-        int size = getSizeOfShortestQueue(workingTicketOffices);
+        var ticketOfficesWithFreePositionsInQueue = workingTicketOffices
+            .stream()
+            .filter(ticketOffice -> {
+                var step = MapManager.getTicketOfficeQueueStep(ticketOffice);
+                Point nextClientInQueuePosition;
 
-        var shortestQueueTicketOffices = workingTicketOffices.stream()
+                if (ticketOffice.getQueue().isEmpty()){
+                    nextClientInQueuePosition = MapManager.GetInitialPoint(ticketOffice);
+                }
+                else {
+                    var lastClientInQueuePosition = new Point(ticketOffice.getQueue().get(ticketOffice.getQueue().size() - 1).getPosition());
+                    lastClientInQueuePosition.translate(step.x, step.y);
+                    nextClientInQueuePosition = lastClientInQueuePosition;
+                }
+
+                return MapManager.IsSegmentFree(new Segment(nextClientInQueuePosition, nextClientInQueuePosition), this);
+            })
+            .collect(Collectors.toCollection(ArrayList::new));
+
+        int size = getSizeOfShortestQueue(ticketOfficesWithFreePositionsInQueue);
+
+        var shortestQueueTicketOffices = ticketOfficesWithFreePositionsInQueue.stream()
             .filter(ticketOffice -> ticketOffice.getQueue().size() == size)
             .collect(Collectors.toCollection(ArrayList::new));
 

--- a/backend/station_manager/app/src/test/java/com/StationManager/app/domain/train_station/HallTest.java
+++ b/backend/station_manager/app/src/test/java/com/StationManager/app/domain/train_station/HallTest.java
@@ -373,4 +373,43 @@ class HallTest {
             Arguments.of(Direction.Right, new Segment(new Point(12, 3), new Point(13, 5)))
         );
     }
+
+    @Test
+    @DisplayName(
+        "Creating two ticket offices, placing them the way that collision occurs when both ticket " +
+            "offices have 2 clients. On adding new client, this collision should be avoided and" +
+            "new client should be added to queue, next free position of which is free")
+    void testTicketOfficeQueueWithFreeSpacesFiltration() {
+        Hall hall = getHall();
+
+        Segment ticketOfficeSegment1 = new Segment(new Point(1, 0), new Point(3, 1));
+        Segment ticketOfficeSegment2 = new Segment(new Point(0, 2), new Point(1, 4));
+        TicketOffice ticketOffice1 = new TicketOffice(1, ticketOfficeSegment1, Direction.Up, 5);
+        TicketOffice ticketOffice2 = new TicketOffice(1, ticketOfficeSegment2, Direction.Left, 5);
+
+        hall.addTicketOffice(ticketOffice1);
+        hall.addTicketOffice(ticketOffice2);
+
+        Client client1 = getClient(1, new Privilegy("ordinary", 0), new Point(3, 4));
+        Client client2 = getClient(2, new Privilegy("ordinary", 0), new Point(3, 5));
+        Client client3 = getClient(3, new Privilegy("ordinary", 0), new Point(3, 6));
+        Client client4 = getClient(4, new Privilegy("ordinary", 0), new Point(3, 7));
+        Client client5 = getClient(5, new Privilegy("ordinary", 0), new Point(3, 8));
+
+        ticketOffice1.addClient(client1);
+        ticketOffice2.addClient(client2);
+        ticketOffice2.addClient(client3);
+
+        hall.addClient(client4);
+        hall.assignToTicketOffice(client4);
+        hall.addClient(client5);
+        hall.assignToTicketOffice(client5);
+
+        var expectedClientsQueue = new LinkedList<Client>();
+        expectedClientsQueue.add(getClient(2, new Privilegy("ordinary", 0), new Point(3, 3)));
+        expectedClientsQueue.add(getClient(3, new Privilegy("ordinary", 0), new Point(4, 3)));
+        expectedClientsQueue.add(getClient(4, new Privilegy("ordinary", 0), new Point(5, 3)));
+        expectedClientsQueue.add(getClient(5, new Privilegy("ordinary", 0), new Point(6, 3)));
+        assertIterableEquals(expectedClientsQueue, hall.getTicketOffices().get(1).getQueue());
+    }
 }


### PR DESCRIPTION
Added solution to queues colision. On assigning new client to ticket office in hall, now it fill filter ticket offices, which has free next position in queue.

Also added unit test to check work of this fix. 